### PR TITLE
Shell scripts for 3DCityDB

### DIFF
--- a/ShellScripts/3DCityDB/README.md
+++ b/ShellScripts/3DCityDB/README.md
@@ -1,6 +1,6 @@
-## Useful information about scripts placed in this folder
+# Useful information about scripts placed in this folde
 
-### empty_3DCityDB.sh
+__empty_3DCityDB.sh__
 
 * The purpose of this script is to empty a 3DCityDB database. To do so, it drops
 the 3DCityDB database and creates a new one with the same name.

--- a/ShellScripts/3DCityDB/README.md
+++ b/ShellScripts/3DCityDB/README.md
@@ -2,19 +2,40 @@
 
 This folder contains shell scripts relative to 3DCityDB. They are listed consequently with a description and usage information.
 
-### empty_3DCityDB.sh
+### create_3DCityDB.sh
 
-* The purpose of this script is to empty a 3DCityDB database. To do so, it drops
-the 3DCityDB database and creates a new one with the same name.
+* The purpose of this script is to create a new __local__ 3DCityDB database.
+
+* It waits for the following parameters:
+    * database name
+    * database owner.
+
+* It must be placed in
+`<path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/`
+
+* It must be invocated where it stands.
+
+* You will be prompted by 3DCityDB to provide a SRID and corresponding SRS. If
+you work with the data of Lyon, provide the following values:
+    * When asked for `Please enter a valid SRID (e.g., 3068 for DHDN/Soldner Berlin):` , enter : `3946` (which is the standard coordinate system for Lyon)
+    * When asked for `Please enter the corresponding SRSName to be used in GML exports (e.g., urn:ogc:def:crs, crs:EPSG::3068, crs:EPSG::5783):` , enter : `crs:EPSG::3946`
+
+### empty_3DCityDB.sh
+
+* The purpose of this script is to empty a __local__ 3DCityDB database. To do
+so, it drops the 3DCityDB database and creates a new one with the same name.
 
 * It waits for the following parameters:
     * database name
     * database owner
 
-* It must be placed in <path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/
-to work correctly.
+* It must be placed in
+`<path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/`
 
-* It only works for a emptying a local database
+* It is based on the create_3DCityDB.sh which must also be placed in
+`<path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/`
+
+* It must be invocated where it stands.
 
 * You will be prompted by 3DCityDB to provide a SRID and corresponding SRS. If
 you work with the data of Lyon, provide the following values:

--- a/ShellScripts/3DCityDB/README.md
+++ b/ShellScripts/3DCityDB/README.md
@@ -1,0 +1,20 @@
+## Useful information about scripts placed in this folder
+
+### empty_3DCityDB.sh
+
+* The purpose of this script is to empty a 3DCityDB database. To do so, it drops
+the 3DCityDB database and creates a new one with the same name.
+
+* It waits for the following parameters:
+    * database name
+    * database owner
+
+* It must be placed in <path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/
+to work correctly.
+
+* It only works for a emptying a local database
+
+* You will be prompted by 3DCityDB to provide a SRID and corresponding SRS. If
+you work with the data of Lyon, provide the following values:
+    * When asked for `Please enter a valid SRID (e.g., 3068 for DHDN/Soldner Berlin):` , enter : `3946` (which is the standard coordinate system for Lyon)
+    * When asked for `Please enter the corresponding SRSName to be used in GML exports (e.g., urn:ogc:def:crs, crs:EPSG::3068, crs:EPSG::5783):` , enter : `crs:EPSG::3946`

--- a/ShellScripts/3DCityDB/README.md
+++ b/ShellScripts/3DCityDB/README.md
@@ -1,4 +1,8 @@
-__empty_3DCityDB.sh__
+# 3DCityDB shell scripts
+
+This folder contains shell scripts relative to 3DCityDB. They are listed consequently with a description and usage information.
+
+### empty_3DCityDB.sh
 
 * The purpose of this script is to empty a 3DCityDB database. To do so, it drops
 the 3DCityDB database and creates a new one with the same name.

--- a/ShellScripts/3DCityDB/README.md
+++ b/ShellScripts/3DCityDB/README.md
@@ -1,5 +1,3 @@
-# Useful information about scripts placed in this folde
-
 __empty_3DCityDB.sh__
 
 * The purpose of this script is to empty a 3DCityDB database. To do so, it drops

--- a/ShellScripts/3DCityDB/create_3DCityDB.sh
+++ b/ShellScripts/3DCityDB/create_3DCityDB.sh
@@ -1,0 +1,33 @@
+# !/bin/sh
+
+# This script creates a local 3DCityDB database. It waits for the following
+# parameters: $1: database name and $2: database owner.
+
+# DISCLAIMER: 
+#  * This script must be placed in 
+#  <path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/ 
+#  * Only works for a local database
+
+# This script only works when invocated where it stands...
+cd "$(dirname "$0")" || exit
+
+# Check that parameters are correctly provided
+if [ $# != 2 ]
+  then
+    echo "Two parameters must be provided to this script: database name and database owner"
+    exit 1
+fi
+
+# Create empty database
+# sudo su postgres
+createdb -O $2 $1
+# exit
+
+# Add the postgis extension to the database
+psql -d $1 -c 'create extension postgis;'
+
+# Edit the database configuration
+sed -e "s/PGUSER=.*$/PGUSER=${2}/" -e "s/CITYDB=.*$/CITYDB=${1}/" -i CREATE_DB.sh
+
+# Run 3DCityDB CREATE_DB.sql script
+psql -d ${1} -U ${2} -f CREATE_DB.sql

--- a/ShellScripts/3DCityDB/empty_3DCityDB.sh
+++ b/ShellScripts/3DCityDB/empty_3DCityDB.sh
@@ -1,0 +1,34 @@
+# !/bin/sh
+
+# WARNING: This script must be placed in <path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/ to work. 
+
+# This script drops a 3DCityDB database and creates a new one with the same
+# name. It waits for the following  parameters: $1: database name and
+# $2: database owner.  
+
+# This script only works when invocated where it stands...
+cd "$(dirname "$0")" || exit
+
+# Check that parameters are correctly provided
+if [ $# != 2 ]
+  then
+    echo "Two parameters must be provided to this script: database name and database owner"
+    exit 1
+fi
+
+# Drop database
+dropdb -U $2 $1
+
+# Create empty database
+# sudo su postgres
+createdb -O $2 $1
+# exit
+
+# Add the postgis extension to the database
+psql -d $1 -c 'create extension postgis;'
+
+# Edit the database configuration
+sed -e "s/PGUSER=.*$/PGUSER=${2}/" -e "s/CITYDB=.*$/CITYDB=${1}/" -i CREATE_DB.sh
+
+# Run 3DCityDB CREATE_DB.sql script
+psql -d ${1} -U ${2} -f CREATE_DB.sql 

--- a/ShellScripts/3DCityDB/empty_3DCityDB.sh
+++ b/ShellScripts/3DCityDB/empty_3DCityDB.sh
@@ -1,10 +1,13 @@
 # !/bin/sh
 
-# WARNING: This script must be placed in <path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/ to work. 
-
 # This script drops a 3DCityDB database and creates a new one with the same
 # name. It waits for the following  parameters: $1: database name and
-# $2: database owner.  
+# $2: database owner.
+
+# DISCLAIMER: 
+#  * This script must be placed in 
+#  <path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/ 
+#  * Only works for a emptying a local database
 
 # This script only works when invocated where it stands...
 cd "$(dirname "$0")" || exit

--- a/ShellScripts/3DCityDB/empty_3DCityDB.sh
+++ b/ShellScripts/3DCityDB/empty_3DCityDB.sh
@@ -8,6 +8,8 @@
 #  * This script must be placed in 
 #  <path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/ 
 #  * Only works for a emptying a local database
+#  * It is based on create_3DCityDB.sh which must also be placed in 
+#  <path_to_3DCityDB-Importer-Exporter>/3dcitydb/postgresql/
 
 # This script only works when invocated where it stands...
 cd "$(dirname "$0")" || exit
@@ -22,16 +24,5 @@ fi
 # Drop database
 dropdb -U $2 $1
 
-# Create empty database
-# sudo su postgres
-createdb -O $2 $1
-# exit
-
-# Add the postgis extension to the database
-psql -d $1 -c 'create extension postgis;'
-
-# Edit the database configuration
-sed -e "s/PGUSER=.*$/PGUSER=${2}/" -e "s/CITYDB=.*$/CITYDB=${1}/" -i CREATE_DB.sh
-
-# Run 3DCityDB CREATE_DB.sql script
-psql -d ${1} -U ${2} -f CREATE_DB.sql 
+# Recreate the database using create_3DCityDB script
+./create_3DCityDB.sh $1 $2


### PR DESCRIPTION
Add two shell scripts utilities for 3DCityDB:
 * create_3DCityDB.sh which creates a local 3DCityDB database
 * empty_3DCityDB.sh which empties a local 3DCityDB database